### PR TITLE
Ignore whitespace in media types

### DIFF
--- a/src/Network/HTTP/Media/MediaType/Internal.hs
+++ b/src/Network/HTTP/Media/MediaType/Internal.hs
@@ -39,9 +39,11 @@ instance IsString MediaType where
     fromString str = flip fromMaybe (parseAccept $ BS.fromString str) $
         error $ "Invalid media type literal " ++ str
 
+
+
 instance Accept MediaType where
     parseAccept bs = do
-        let pieces = BS.split semi bs
+        let pieces = map trimBS $ BS.split semi bs
         guard $ not (null pieces)
         let (m : ps) = pieces
             (a, b)   = breakByte slash m

--- a/src/Network/HTTP/Media/Utils.hs
+++ b/src/Network/HTTP/Media/Utils.hs
@@ -33,11 +33,11 @@ breakByte w = fmap BS.tail . BS.breakByte w
 
 
 ------------------------------------------------------------------------------
--- | Trims space characters from both ends of a ByteString.
+-- | Trims tab and space characters from both ends of a ByteString.
 trimBS :: ByteString -> ByteString
-trimBS = BS.reverse . dropSpace . BS.reverse . dropSpace
+trimBS = fst . BS.spanEnd isLWS . snd . BS.span isLWS
   where
-    dropSpace = BS.dropWhile (== space)
+    isLWS c = (c == space) || (c == htab)
 
 
 ------------------------------------------------------------------------------
@@ -63,6 +63,6 @@ isValidChar c = c >= 97 && c <= 122 || c >= 48 && c <= 57 ||
 
 ------------------------------------------------------------------------------
 -- | 'ByteString' compatible characters.
-slash, semi, comma, space, equal, hyphen, zero :: Word8
-[slash, semi, comma, space, equal, hyphen, zero] =
-    [47, 59, 44, 32, 61, 45, 48]
+slash, semi, comma, space, equal, hyphen, zero, htab :: Word8
+[slash, semi, comma, space, equal, hyphen, zero, htab] =
+    [47, 59, 44, 32, 61, 45, 48, 9]

--- a/test/Network/HTTP/Media/MediaType/Tests.hs
+++ b/test/Network/HTTP/Media/MediaType/Tests.hs
@@ -190,12 +190,14 @@ testMostSpecific = testGroup "mostSpecific"
 testParseAccept :: Test
 testParseAccept = testProperty "parseAccept" $ do
     media <- genMediaType
-    let main   = mainType media
-        sub    = subType media
-        params = parameters media
-        parsed = parseAccept $ main <> "/" <> sub <> mconcat
+    let main          = mainType media
+        sub           = subType media
+        params        = parameters media
+        parsedNoSpace = parseAccept $ main <> "/" <> sub <> mconcat
             (map (uncurry ((<>) . (<> "=") . (";" <>))) $ Map.toList params)
-    return $ parsed == Just media
+        parsedSpace   = parseAccept $ main <> "/" <> sub <> mconcat
+            (map (uncurry ((<>) . (<> "=") . (" ; " <>))) $ Map.toList params)
+    return $ parsedNoSpace == Just media && parsedSpace == Just media
 
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
this should fix #7 

This is a very narrow fix: it only deals with media types, not any of the other accept-X, which also meed the fix because they also use the `weight` production. Therefore, I've tossed `trimLWS` in `Utils.hs` for re-use.

For reference, I found:

```
weight = OWS ";" OWS "q=" qvalue
...
media-range    = ( "*/*"
                 / ( type "/" "*" )
                 / ( type "/" subtype )
                 ) *( OWS ";" OWS parameter )
accept-params  = weight *( accept-ext )
accept-ext = OWS ";" OWS token [ "=" ( token / quoted-string ) ]
```

in [RFC7031](http://tools.ietf.org/html/rfc7231) with `OWS            = *( SP / HTAB )` from [RFC7030](http://tools.ietf.org/html/rfc7230).

