### PR TITLE
Derive Ord instance for MediaType.

### DIFF
--- a/src/Network/HTTP/Media/MediaType/Internal.hs
+++ b/src/Network/HTTP/Media/MediaType/Internal.hs
@@ -31,7 +31,7 @@ data MediaType = MediaType
     { mainType   :: CI ByteString  -- ^ The main type of the MediaType
     , subType    :: CI ByteString  -- ^ The sub type of the MediaType
     , parameters :: Parameters     -- ^ The parameters of the MediaType
-    } deriving (Eq)
+    } deriving (Eq, Ord)
 
 instance Show MediaType where
     show = BS.unpack . renderHeader


### PR DESCRIPTION
I need this in order to give end points in [auto-generated rest api documentation](https://github.com/haskell-servant/servant-docs) a canonical order.