### PR TITLE
Allow base-4.12

### DIFF
--- a/http-media.cabal
+++ b/http-media.cabal
@@ -70,7 +70,7 @@ library
     Network.HTTP.Media.Utils
 
   build-depends:
-    base             >= 4.7  && < 4.11,
+    base             >= 4.7  && < 4.12,
     bytestring       >= 0.10 && < 0.11,
     case-insensitive >= 1.0  && < 1.3,
     containers       >= 0.5  && < 0.6,
@@ -114,7 +114,7 @@ test-suite test-http-media
     Network.HTTP.Media.Utils
 
   build-depends:
-    base                       >= 4.7  && < 4.11,
+    base                       >= 4.7  && < 4.12,
     bytestring                 >= 0.10 && < 0.11,
     case-insensitive           >= 1.0  && < 1.3,
     containers                 >= 0.5  && < 0.6,


### PR DESCRIPTION
Note: maintainers can revise bounds on http://hackage.haskell.org/package/http-media/maintain, so you don't need to assemble a new release