### PR TITLE
Bump lower bound on base to >=4.8

### DIFF
--- a/http-media.cabal
+++ b/http-media.cabal
@@ -71,7 +71,7 @@ library
     Network.HTTP.Media.Utils
 
   build-depends:
-    base             >= 4.7  && < 4.13,
+    base             >= 4.8  && < 4.13,
     bytestring       >= 0.10 && < 0.11,
     case-insensitive >= 1.0  && < 1.3,
     containers       >= 0.5  && < 0.7,


### PR DESCRIPTION
There were install plans failing with

```
Build profile: -w ghc-7.8.4 -O1
In order, the following will be built (use -v for more details):
 - http-media-0.8.0.0 (lib) (first run)
Configuring library for http-media-0.8.0.0..
Preprocessing library for http-media-0.8.0.0..
Building library for http-media-0.8.0.0..
[ 1 of 13] Compiling Network.HTTP.Media.Utils ( src/Network/HTTP/Media/Utils.hs, /code/mess/http-media-0.8.0.0/.dist-newstyle-aa6ee86615bf83600e1a9cc59f3dab339d9b62d6eacba769f14a98fa1bfef1944c916e7d0697650e9fa9296f78441ac1098d8bdc832acfacbda4516e021f32e3/build/x86_64-linux/ghc-7.8.4/http-media-0.8.0.0/build/Network/HTTP/Media/Utils.o )


src/Network/HTTP/Media/Utils.hs:57:20: Not in scope: ‘<$>’

src/Network/HTTP/Media/Utils.hs:57:40: Not in scope: ‘<*>’

src/Network/HTTP/Media/Utils.hs:74:21: Not in scope: ‘<$>’

src/Network/HTTP/Media/Utils.hs:74:39: Not in scope: ‘<*>’
```

I made a revision on Hackage, https://hackage.haskell.org/package/http-media-0.8.0.0/revisions/, so no immediate action is required.