### PR TITLE
Allow ghc-8.8.1, switch to tasty

### DIFF
--- a/http-media.cabal
+++ b/http-media.cabal
@@ -128,8 +128,8 @@ test-suite test-http-media
     containers                 >= 0.5  && < 0.7,
     utf8-string                >= 0.3  && < 1.1,
     QuickCheck                 >= 2.8  && < 2.14,
-    test-framework             >= 0.8  && < 0.9,
-    test-framework-quickcheck2 >= 0.3  && < 0.4
+    tasty                      >= 0.11 && < 1.3,
+    tasty-quickcheck           >= 0.8  && < 0.11
 
 source-repository head
   type:     git

--- a/http-media.cabal
+++ b/http-media.cabal
@@ -71,7 +71,7 @@ library
     Network.HTTP.Media.Utils
 
   build-depends:
-    base             >= 4.8  && < 4.13,
+    base             >= 4.8  && < 4.14,
     bytestring       >= 0.10 && < 0.11,
     case-insensitive >= 1.0  && < 1.3,
     containers       >= 0.5  && < 0.7,
@@ -122,7 +122,7 @@ test-suite test-http-media
     Network.HTTP.Media.Utils
 
   build-depends:
-    base                       >= 4.7  && < 4.13,
+    base                       >= 4.7  && < 4.14,
     bytestring                 >= 0.10 && < 0.11,
     case-insensitive           >= 1.0  && < 1.3,
     containers                 >= 0.5  && < 0.7,

--- a/test/Network/HTTP/Media/Accept/Tests.hs
+++ b/test/Network/HTTP/Media/Accept/Tests.hs
@@ -1,15 +1,15 @@
 ------------------------------------------------------------------------------
 module Network.HTTP.Media.Accept.Tests (tests) where
 
-import           Test.Framework                       (Test, testGroup)
-import           Test.Framework.Providers.QuickCheck2 (testProperty)
+import           Test.Tasty                            (TestTree, testGroup)
+import           Test.Tasty.QuickCheck                 (testProperty)
 
 import           Network.HTTP.Media.Accept
 import           Network.HTTP.Media.Gen
 
 
 ------------------------------------------------------------------------------
-tests :: [Test]
+tests :: [TestTree]
 tests =
     [ testMatches
     , testMoreSpecificThan
@@ -17,7 +17,7 @@ tests =
 
 
 ------------------------------------------------------------------------------
-testMatches :: Test
+testMatches :: TestTree
 testMatches = testGroup "matches"
     [ testProperty "Does match" $ do
         string <- genByteString
@@ -32,6 +32,6 @@ testMatches = testGroup "matches"
 ------------------------------------------------------------------------------
 -- | Note that this test never actually generates any strings, as they are not
 -- required for the 'moreSpecificThan' test.
-testMoreSpecificThan :: Test
+testMoreSpecificThan :: TestTree
 testMoreSpecificThan = testProperty "moreSpecificThan" $
     (not .) . moreSpecificThan <$> genByteString <*> genByteString

--- a/test/Network/HTTP/Media/Charset/Tests.hs
+++ b/test/Network/HTTP/Media/Charset/Tests.hs
@@ -5,8 +5,8 @@ import qualified Data.ByteString.Char8                as BS
 
 import           Control.Monad                        (join)
 import           Data.String                          (fromString)
-import           Test.Framework                       (Test, testGroup)
-import           Test.Framework.Providers.QuickCheck2 (testProperty)
+import           Test.Tasty                           (TestTree, testGroup)
+import           Test.Tasty.QuickCheck                (testProperty)
 import           Test.QuickCheck                      ((===))
 
 import           Network.HTTP.Media.Accept
@@ -16,7 +16,7 @@ import           Network.HTTP.Media.RenderHeader
 
 
 ------------------------------------------------------------------------------
-tests :: [Test]
+tests :: [TestTree]
 tests =
     [ testEq
     , testShow
@@ -29,7 +29,7 @@ tests =
 
 ------------------------------------------------------------------------------
 -- Equality is derived, but we test it here to get 100% coverage.
-testEq :: Test
+testEq :: TestTree
 testEq = testGroup "Eq"
     [ testProperty "==" $ do
         enc <- genCharset
@@ -42,21 +42,21 @@ testEq = testGroup "Eq"
 
 
 ------------------------------------------------------------------------------
-testShow :: Test
+testShow :: TestTree
 testShow = testProperty "show" $ do
     enc <- genCharset
     return $ parseAccept (BS.pack $ show enc) === Just enc
 
 
 ------------------------------------------------------------------------------
-testFromString :: Test
+testFromString :: TestTree
 testFromString = testProperty "fromString" $ do
     enc <- genCharset
     return $ enc === fromString (show enc)
 
 
 ------------------------------------------------------------------------------
-testMatches :: Test
+testMatches :: TestTree
 testMatches = testGroup "matches"
     [ testProperty "Equal values match" $
         join matches <$> genCharset
@@ -68,7 +68,7 @@ testMatches = testGroup "matches"
 
 
 ------------------------------------------------------------------------------
-testMoreSpecific :: Test
+testMoreSpecific :: TestTree
 testMoreSpecific = testGroup "moreSpecificThan"
     [ testProperty "Against *" $
         flip moreSpecificThan anything <$> genConcreteCharset
@@ -80,7 +80,7 @@ testMoreSpecific = testGroup "moreSpecificThan"
 
 
 ------------------------------------------------------------------------------
-testParseAccept :: Test
+testParseAccept :: TestTree
 testParseAccept = testGroup "parseAccept"
     [ testProperty "Empty" $
         parseAccept "" === (Nothing :: Maybe Charset)

--- a/test/Network/HTTP/Media/Encoding/Tests.hs
+++ b/test/Network/HTTP/Media/Encoding/Tests.hs
@@ -5,8 +5,8 @@ import qualified Data.ByteString.Char8                as BS
 
 import           Control.Monad                        (join)
 import           Data.String                          (fromString)
-import           Test.Framework                       (Test, testGroup)
-import           Test.Framework.Providers.QuickCheck2 (testProperty)
+import           Test.Tasty                            (TestTree, testGroup)
+import           Test.Tasty.QuickCheck                 (testProperty)
 import           Test.QuickCheck                      ((===))
 
 import           Network.HTTP.Media.Accept
@@ -15,7 +15,7 @@ import           Network.HTTP.Media.RenderHeader
 
 
 ------------------------------------------------------------------------------
-tests :: [Test]
+tests :: [TestTree]
 tests =
     [ testEq
     , testShow
@@ -28,7 +28,7 @@ tests =
 
 ------------------------------------------------------------------------------
 -- Equality is derived, but we test it here to get 100% coverage.
-testEq :: Test
+testEq :: TestTree
 testEq = testGroup "Eq"
     [ testProperty "==" $ do
         enc <- genEncoding
@@ -41,21 +41,21 @@ testEq = testGroup "Eq"
 
 
 ------------------------------------------------------------------------------
-testShow :: Test
+testShow :: TestTree
 testShow = testProperty "show" $ do
     enc <- genEncoding
     return $ parseAccept (BS.pack $ show enc) === Just enc
 
 
 ------------------------------------------------------------------------------
-testFromString :: Test
+testFromString :: TestTree
 testFromString = testProperty "fromString" $ do
     enc <- genEncoding
     return $ enc === fromString (show enc)
 
 
 ------------------------------------------------------------------------------
-testMatches :: Test
+testMatches :: TestTree
 testMatches = testGroup "matches"
     [ testProperty "Equal values match" $
         join matches <$> genEncoding
@@ -67,7 +67,7 @@ testMatches = testGroup "matches"
 
 
 ------------------------------------------------------------------------------
-testMoreSpecific :: Test
+testMoreSpecific :: TestTree
 testMoreSpecific = testGroup "moreSpecificThan"
     [ testProperty "Against *" $
         flip moreSpecificThan anything <$> genConcreteEncoding
@@ -79,7 +79,7 @@ testMoreSpecific = testGroup "moreSpecificThan"
 
 
 ------------------------------------------------------------------------------
-testParseAccept :: Test
+testParseAccept :: TestTree
 testParseAccept = testGroup "parseAccept"
     [ testProperty "Empty" $
         parseAccept "" === Just identity

--- a/test/Network/HTTP/Media/Language/Tests.hs
+++ b/test/Network/HTTP/Media/Language/Tests.hs
@@ -6,8 +6,8 @@ import qualified Data.ByteString.Char8                as BS
 import           Control.Monad                        (join)
 import           Data.Monoid                          ((<>))
 import           Data.String                          (fromString)
-import           Test.Framework                       (Test, testGroup)
-import           Test.Framework.Providers.QuickCheck2 (testProperty)
+import           Test.Tasty                           (TestTree, testGroup)
+import           Test.Tasty.QuickCheck                (testProperty)
 import           Test.QuickCheck                      ((===))
 
 import           Network.HTTP.Media.Accept
@@ -17,7 +17,7 @@ import           Network.HTTP.Media.RenderHeader
 
 
 ------------------------------------------------------------------------------
-tests :: [Test]
+tests :: [TestTree]
 tests =
     [ testEq
     , testShow
@@ -30,7 +30,7 @@ tests =
 
 ------------------------------------------------------------------------------
 -- Equality is derived, but we test it here to get 100% coverage.
-testEq :: Test
+testEq :: TestTree
 testEq = testGroup "Eq"
     [ testProperty "==" $ do
         lang <- genLanguage
@@ -43,21 +43,21 @@ testEq = testGroup "Eq"
 
 
 ------------------------------------------------------------------------------
-testShow :: Test
+testShow :: TestTree
 testShow = testProperty "show" $ do
     lang <- genLanguage
     return $ parseAccept (BS.pack $ show lang) === Just lang
 
 
 ------------------------------------------------------------------------------
-testFromString :: Test
+testFromString :: TestTree
 testFromString = testProperty "fromString" $ do
     lang <- genLanguage
     return $ lang === fromString (show lang)
 
 
 ------------------------------------------------------------------------------
-testMatches :: Test
+testMatches :: TestTree
 testMatches = testGroup "matches"
     [ testProperty "Equal values match" $
         join matches <$> genLanguage
@@ -73,7 +73,7 @@ testMatches = testGroup "matches"
 
 
 ------------------------------------------------------------------------------
-testMoreSpecific :: Test
+testMoreSpecific :: TestTree
 testMoreSpecific = testGroup "moreSpecificThan"
     [ testProperty "Against *" $
         flip moreSpecificThan anything <$> genConcreteLanguage
@@ -89,7 +89,7 @@ testMoreSpecific = testGroup "moreSpecificThan"
 
 
 ------------------------------------------------------------------------------
-testParseAccept :: Test
+testParseAccept :: TestTree
 testParseAccept = testGroup "parseAccept"
     [ testProperty "Valid parse"$ do
         lang <- genLanguage

--- a/test/Network/HTTP/Media/MediaType/Tests.hs
+++ b/test/Network/HTTP/Media/MediaType/Tests.hs
@@ -9,8 +9,8 @@ import           Data.ByteString                       (ByteString)
 import           Data.CaseInsensitive                  (foldedCase)
 import           Data.Monoid                           ((<>))
 import           Data.String                           (fromString)
-import           Test.Framework                        (Test, testGroup)
-import           Test.Framework.Providers.QuickCheck2  (testProperty)
+import           Test.Tasty                            (TestTree, testGroup)
+import           Test.Tasty.QuickCheck                 (testProperty)
 import           Test.QuickCheck                       (property, (.&&.), (===))
 import           Test.QuickCheck.Gen                   (Gen)
 
@@ -23,7 +23,7 @@ import           Network.HTTP.Media.RenderHeader       (renderHeader)
 
 
 ------------------------------------------------------------------------------
-tests :: [Test]
+tests :: [TestTree]
 tests =
     [ testEq
     , testShow
@@ -38,7 +38,7 @@ tests =
 
 ------------------------------------------------------------------------------
 -- Equality is derived, but we test it here to get 100% coverage.
-testEq :: Test
+testEq :: TestTree
 testEq = testGroup "Eq"
     [ testProperty "==" $ do
         media <- genMediaType
@@ -51,21 +51,21 @@ testEq = testGroup "Eq"
 
 
 ------------------------------------------------------------------------------
-testShow :: Test
+testShow :: TestTree
 testShow = testProperty "show" $ do
     media <- genMediaType
     return $ parseAccept (BS.pack $ show media) === Just media
 
 
 ------------------------------------------------------------------------------
-testFromString :: Test
+testFromString :: TestTree
 testFromString = testProperty "fromString" $ do
     media <- genMediaType
     return $ media === fromString (show media)
 
 
 ------------------------------------------------------------------------------
-testHas :: Test
+testHas :: TestTree
 testHas = testGroup "(/?)"
     [ testProperty "True for property it has" $ do
         media <- genWithParams
@@ -78,7 +78,7 @@ testHas = testGroup "(/?)"
 
 
 ------------------------------------------------------------------------------
-testGet :: Test
+testGet :: TestTree
 testGet = testGroup "(/.)"
     [ testProperty "Retrieves property it has" $ do
         media  <- genWithParams
@@ -92,7 +92,7 @@ testGet = testGroup "(/.)"
 
 
 ------------------------------------------------------------------------------
-testMatches :: Test
+testMatches :: TestTree
 testMatches = testGroup "matches"
     [ testProperty "Equal values match" $ do
         media <- genMediaType
@@ -131,7 +131,7 @@ testMatches = testGroup "matches"
 
 
 ------------------------------------------------------------------------------
-testMoreSpecificThan :: Test
+testMoreSpecificThan :: TestTree
 testMoreSpecificThan = testGroup "moreSpecificThan"
     [ testProperty "Against */*" $
         liftM (`moreSpecificThan` anything) genMaybeSubStar
@@ -156,7 +156,7 @@ testMoreSpecificThan = testGroup "moreSpecificThan"
 
 
 ------------------------------------------------------------------------------
-testParseAccept :: Test
+testParseAccept :: TestTree
 testParseAccept = testGroup "parseAccept"
     [ testProperty "Valid parse" $ do
         media <- genMediaType

--- a/test/Network/HTTP/Media/Tests.hs
+++ b/test/Network/HTTP/Media/Tests.hs
@@ -8,8 +8,8 @@ import           Data.List                             (nubBy)
 import           Data.Map                              (empty)
 import           Data.Monoid                           ((<>))
 import           Data.Word                             (Word16)
-import           Test.Framework                        (Test, testGroup)
-import           Test.Framework.Providers.QuickCheck2  (testProperty)
+import           Test.Tasty                            (TestTree, testGroup)
+import           Test.Tasty.QuickCheck                 (testProperty)
 import           Test.QuickCheck
 
 import           Network.HTTP.Media                    hiding (parameters,
@@ -21,7 +21,7 @@ import           Network.HTTP.Media.Quality
 
 
 ------------------------------------------------------------------------------
-tests :: [Test]
+tests :: [TestTree]
 tests =
     [ testParse
     , testMatchAccept
@@ -34,7 +34,7 @@ tests =
 
 
 ------------------------------------------------------------------------------
-testParse :: Test
+testParse :: TestTree
 testParse = testGroup "parseQuality"
     [ testProperty "Without quality" $ do
         media    <- medias
@@ -64,17 +64,17 @@ testParse = testGroup "parseQuality"
 
 
 ------------------------------------------------------------------------------
-testMatchAccept :: Test
+testMatchAccept :: TestTree
 testMatchAccept = testMatch "Accept" matchAccept renderHeader
 
 
 ------------------------------------------------------------------------------
-testMapAccept :: Test
+testMapAccept :: TestTree
 testMapAccept = testMap "Accept" mapAccept renderHeader
 
 
 ------------------------------------------------------------------------------
-testMatchContent :: Test
+testMatchContent :: TestTree
 testMatchContent = testGroup "matchContent"
     [ testProperty "Matches" $ do
         media <- genMediaType
@@ -95,7 +95,7 @@ testMatchContent = testGroup "matchContent"
 
 
 ------------------------------------------------------------------------------
-testMapContent :: Test
+testMapContent :: TestTree
 testMapContent = testGroup "mapContent"
     [ testProperty "Matches" $ do
         media <- genMediaType
@@ -108,12 +108,12 @@ testMapContent = testGroup "mapContent"
 
 
 ------------------------------------------------------------------------------
-testMatchQuality :: Test
+testMatchQuality :: TestTree
 testMatchQuality = testMatch "Quality" matchQuality id
 
 
 ------------------------------------------------------------------------------
-testMapQuality :: Test
+testMapQuality :: TestTree
 testMapQuality = testMap "Quality" mapQuality id
 
 
@@ -122,7 +122,7 @@ testMatch
     :: String
     -> ([MediaType] -> a -> Maybe MediaType)
     -> ([Quality MediaType] -> a)
-    -> Test
+    -> TestTree
 testMatch name match qToI = testGroup ("match" ++ name)
     [ testProperty "Most specific" $ do
         media <- genConcreteMediaType
@@ -158,7 +158,7 @@ testMatch name match qToI = testGroup ("match" ++ name)
 testQuality
     :: ([MediaType] -> a -> Maybe MediaType)
     -> ([Quality MediaType] -> a)
-    -> Test
+    -> TestTree
 testQuality match qToI = testGroup "Quality"
     [ testProperty "Highest quality" $ do
         server <- genServer
@@ -180,7 +180,7 @@ testQuality match qToI = testGroup "Quality"
 testQ0
     :: ([MediaType] -> a -> Maybe MediaType)
     -> ([Quality MediaType] -> a)
-    -> Test
+    -> TestTree
 testQ0 match qToI = testGroup "q=0"
     [ testProperty "Does not choose a q=0" $ do
         server <- genConcreteMediaType
@@ -212,7 +212,7 @@ testMap
     :: String
     -> ([(MediaType, MediaType)] -> a -> Maybe MediaType)
     -> ([Quality MediaType] -> a)
-    -> Test
+    -> TestTree
 testMap name mapf qToI = testGroup ("map" ++ name)
     [ testProperty "Matches" $ do
         server <- genServer

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 module Main (main) where
 
-import           Test.Framework                     (defaultMain, testGroup)
+import           Test.Tasty                        (defaultMain, testGroup)
 
 import qualified Network.HTTP.Media.Accept.Tests    as Accept
 import qualified Network.HTTP.Media.Charset.Tests   as Charset
@@ -13,7 +13,7 @@ import qualified Network.HTTP.Media.Tests           as Media
 
 ------------------------------------------------------------------------------
 main :: IO ()
-main = defaultMain
+main = defaultMain $ testGroup "http-media"
     [ testGroup "Accept"    Accept.tests
     , testGroup "Charset"   Charset.tests
     , testGroup "Encoding"  Encoding.tests


### PR DESCRIPTION
Motivation to change to `tasty`
- it's more maintained
- and it doesn't depend on `regex-base` library which I don't know if is maintained at all