### PR TITLE
Allow bytestring-0.11

### DIFF
--- a/http-media.cabal
+++ b/http-media.cabal
@@ -72,7 +72,7 @@ library
 
   build-depends:
     base             >= 4.8  && < 4.15,
-    bytestring       >= 0.10 && < 0.11,
+    bytestring       >= 0.10 && < 0.12,
     case-insensitive >= 1.0  && < 1.3,
     containers       >= 0.5  && < 0.7,
     utf8-string      >= 0.3  && < 1.1
@@ -123,7 +123,7 @@ test-suite test-http-media
 
   build-depends:
     base             >= 4.7  && < 4.15,
-    bytestring       >= 0.10 && < 0.11,
+    bytestring       >= 0.10 && < 0.12,
     case-insensitive >= 1.0  && < 1.3,
     containers       >= 0.5  && < 0.7,
     utf8-string      >= 0.3  && < 1.1,


### PR DESCRIPTION
Tested using 
```cabal
packages: .
tests: true

constraints:
  bytestring >= 0.11

source-repository-package
  type: git
  location: https://github.com/haskell/text
  tag: v1.2.4.1-rc1
```