### PR TITLE
Add GHC 9.0 support

### DIFF
--- a/http-media.cabal
+++ b/http-media.cabal
@@ -71,7 +71,7 @@ library
     Network.HTTP.Media.Utils
 
   build-depends:
-    base             >= 4.8  && < 4.15,
+    base             >= 4.8  && < 4.16,
     bytestring       >= 0.10 && < 0.12,
     case-insensitive >= 1.0  && < 1.3,
     containers       >= 0.5  && < 0.7,
@@ -122,12 +122,12 @@ test-suite test-http-media
     Network.HTTP.Media.Utils
 
   build-depends:
-    base             >= 4.7  && < 4.15,
+    base             >= 4.7  && < 4.16,
     bytestring       >= 0.10 && < 0.12,
     case-insensitive >= 1.0  && < 1.3,
     containers       >= 0.5  && < 0.7,
     utf8-string      >= 0.3  && < 1.1,
-    QuickCheck       >= 2.8  && < 2.14,
+    QuickCheck       >= 2.8  && < 2.15,
     tasty            >= 0.11 && < 1.3,
     tasty-quickcheck >= 0.8  && < 0.11
 


### PR DESCRIPTION
Dear @zmthy,

- This PR is intentded to enable build `http-media` package via GHC 9.0.
- Summary:
    - Relax `base` to allow `4.15.0.0`.
    - Relax `QuickCheck` to allow `2.14.x` versions.
- Locally tests were passed: 
    ```
    cabal v2-test
    Running 1 test suites...
    Test suite test-http-media: RUNNING...
    Test suite test-http-media: PASS
    Test suite logged to:
    $HOME/http-media/dist-newstyle/build/x86_64-osx/ghc-9.0.1/http-media-0.8.0.0/t/test-http-media/test/http-media-0.8.0.0-test-http-media.log
    1 of 1 test suites (1 of 1 test cases) passed.
    ```

Best regards,
@swamp-agr