### PR TITLE
Support GHC 9.2

### DIFF
--- a/http-media.cabal
+++ b/http-media.cabal
@@ -71,7 +71,7 @@ library
     Network.HTTP.Media.Utils
 
   build-depends:
-    base             >= 4.8  && < 4.16,
+    base             >= 4.8  && < 4.17,
     bytestring       >= 0.10 && < 0.12,
     case-insensitive >= 1.0  && < 1.3,
     containers       >= 0.5  && < 0.7,
@@ -122,7 +122,7 @@ test-suite test-http-media
     Network.HTTP.Media.Utils
 
   build-depends:
-    base             >= 4.8  && < 4.16,
+    base             >= 4.8  && < 4.17,
     bytestring       >= 0.10 && < 0.12,
     case-insensitive >= 1.0  && < 1.3,
     containers       >= 0.5  && < 0.7,


### PR DESCRIPTION
This PR allows `http-media` to use `base-4.16` so that it can be used with `ghc-9.2.1`.