### PR TITLE
Constrain base dependency to just <5

### DIFF
--- a/http-media.cabal
+++ b/http-media.cabal
@@ -71,7 +71,7 @@ library
     Network.HTTP.Media.Utils
 
   build-depends:
-    base             >= 4.8  && < 4.18,
+    base             >= 4.8  && < 5,
     bytestring       >= 0.10 && < 0.12,
     case-insensitive >= 1.0  && < 1.3,
     containers       >= 0.5  && < 0.7,
@@ -122,7 +122,7 @@ test-suite test-http-media
     Network.HTTP.Media.Utils
 
   build-depends:
-    base             >= 4.8  && < 4.18,
+    base             >= 4.8  && < 5,
     bytestring       >= 0.10 && < 0.12,
     case-insensitive >= 1.0  && < 1.3,
     containers       >= 0.5  && < 0.7,


### PR DESCRIPTION
To releave the maintainer from having to bump the base bound every year, this
relaxes the bound such that it likely won't be needed for a long time.

Fixes #43

Passes the test suite on GHC 9.6:
```
 % cabal test
Resolving dependencies...
Build profile: -w ghc-9.6.1 -O1
[...]
1 of 1 test suites (1 of 1 test cases) passed.
```