### PR TITLE
Expose qualityData, add qualityAcceptable function.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+  Exposed `qualityData` accessor.
+
+  Added `isAcceptable` to allow filtering out unacceptable items.
+
 - [Version 0.8.0.0](https://github.com/zmthy/http-media/releases/tag/v0.8.0.0)
 
   Removed official support for GHC 7.8.

--- a/src/Network/HTTP/Media.hs
+++ b/src/Network/HTTP/Media.hs
@@ -40,10 +40,11 @@ module Network.HTTP.Media
     , mapContentLanguage
 
     -- * Quality values
-    , Quality
+    , Quality (qualityData)
     , quality
     , QualityOrder
     , qualityOrder
+    , isAcceptable
     , maxQuality
     , minQuality
     , parseQuality
@@ -343,8 +344,8 @@ matchQuality
     -> Maybe a
 matchQuality options acceptq = do
     guard $ not (null options)
-    Quality m q <- maximumBy (compare `on` fmap qualityOrder) optionsq
-    guard $ q /= 0
+    q@(Quality m _) <- maximumBy (compare `on` fmap qualityOrder) optionsq
+    guard $ isAcceptable q
     return m
   where
     optionsq = reverse $ map addQuality options

--- a/src/Network/HTTP/Media/Quality.hs
+++ b/src/Network/HTTP/Media/Quality.hs
@@ -7,6 +7,7 @@ module Network.HTTP.Media.Quality
     , quality
     , QualityOrder
     , qualityOrder
+    , isAcceptable
     , maxQuality
     , minQuality
     , mostSpecific
@@ -54,6 +55,11 @@ quality x q = Quality x $ flip fromMaybe (readQ q) $
 newtype QualityOrder = QualityOrder Word16
     deriving (Eq, Ord)
 
+------------------------------------------------------------------------------
+-- | 0 means not acceptable
+isAcceptable :: Quality a -> Bool
+isAcceptable (Quality _ 0) = False
+isAcceptable (Quality _ _) = True
 
 ------------------------------------------------------------------------------
 -- | Remove the attached data from a quality value, retaining only the


### PR DESCRIPTION
In our circumstances it's necessary to access "raw" list of qualities instead of using existing machinery to do matching. This has not been possible, since Quality is an opaque type with no field accessors exported. In this PR I expose `qualityData` field accessor.

Furthermore, RFC explicitly adds quality of 0 meaning of being not acceptable. Added a function to test for this.